### PR TITLE
Bump java code up to play 2.2.0

### DIFF
--- a/play-pac4j_java/pom.xml
+++ b/play-pac4j_java/pom.xml
@@ -38,7 +38,7 @@
 		</dependency>
 		<dependency>
 			<groupId>play</groupId>
-			<artifactId>play_2.9.1</artifactId>
+			<artifactId>play_2.10</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 			<dependency>
 				<groupId>play</groupId>
 				<artifactId>play_2.10</artifactId>
-				<version>2.1.0</version>
+				<version>2.2.0</version>
 				<scope>provided</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Call now returns Promise<SimpleResult>.  Create promise using Akka.future;
Note - This method is deprecated in 2.2.0 and should probably be updated.

I wasn't able to get maven working to start with before any changes, so I wasn't able to test any of those changes.
