### PR TITLE
Handle the case where the session variable is set to NULL.

### DIFF
--- a/play-pac4j_java/src/main/java/org/pac4j/play/StorageHelper.java
+++ b/play-pac4j_java/src/main/java/org/pac4j/play/StorageHelper.java
@@ -144,7 +144,11 @@ public final class StorageHelper {
      */
     public static void save(final String sessionId, final String key, final Object value) {
         if (sessionId != null) {
-            save(sessionId + Constants.SEPARATOR + key, value, Config.getSessionTimeout());
+            if (value != null) {
+                save(sessionId + Constants.SEPARATOR + key, value, Config.getSessionTimeout());
+            } else {
+                remove(sessionId + Constants.SEPARATOR + key);
+            }
         }
     }
     


### PR DESCRIPTION
  Certain Play Cache implementations (Typesafe's Redis plugin) do not like setting a field to null, so
  instead of setting the field's value to an empty value, remove the field.
