### PR TITLE
Support for Play 2.4 dynamic routes generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,27 @@ If you want to use a specific client support, you need to add the appropriate de
 
 ### Use client support in your Controller
 
-To use client support, your controllers must inherit from the JavaController class for a Java application:
+To use client support, your controllers must inherit from classes provided by the play-pac4j framework.
+
+**For old style routes generator:**
+
+Your controller must extend the JavaController class for a Java application:
 
     public class Application extends JavaController {
 
-or from the ScalaController trait for a Scala application:
+or inherit the ScalaController trait for a Scala application:
 
     object Application extends ScalaController {
+
+**For new dynamic style routes generator**
+
+Your controller must extend the SecureController class for a Java application:
+
+    public class Application extends SecureController {
+
+or inherit the Security trait for a Scala application:
+
+    class Application extends Controller with Security {
 
 
 ### Define the supported clients

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It's available under the Apache 2 license and based on the [pac4j](https://githu
 <tr><td>Play 2.4</td><td>play-pac4j_java v1.5.x</td><td>play-pac4j_scala2.11 v1.5.x</td></tr>
 </table>
 
-Check [below](#Migration instructions) for migration instructions to play-pac4j 1.5.0.
+Check [below](#migration-instructions) for migration instructions to play-pac4j 1.5.0.
 
 ## Providers supported
 
@@ -365,7 +365,7 @@ Since Play 2.4, the Play framework is migrating to use dependency injection (by 
 
 **Configuring the authentication clients**
 
-In earlier versions we made use of the Global object to configure the authentication clients. The code for play-pac4j can be moved to an eagerly loaded bean. See section [Define the supported clients](#Define the supported clients) to see how this is done now. At this point in time the configuration via the Global object will still work, but consider migrating to DI style.
+In earlier versions we made use of the Global object to configure the authentication clients. The code for play-pac4j can be moved to an eagerly loaded bean. See section [Define the supported clients](#define-the-supported-clients) to see how this is done now. At this point in time the configuration via the Global object will still work, but consider migrating to DI style.
 
 **Moving to dependency injection based routing**
 Play 2.4 advocates the use of dependency injection everywhere. They also made next to the static routes generator, a dynamic routes generator. This is enabled with the setting:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It's available under the Apache 2 license and based on the [pac4j](https://githu
 <tr><td>Play 2.4</td><td>play-pac4j_java v1.5.x</td><td>play-pac4j_scala2.11 v1.5.x</td></tr>
 </table>
 
+Check [below](#Migration instructions) for migration instructions to play-pac4j 1.5.0.
 
 ## Providers supported
 
@@ -123,15 +124,18 @@ If you want to use a specific client support, you need to add the appropriate de
     )
 ```
 
-### Define the supported clients
+### Use client support in your Controller
 
-To use client support, your application must inherit from the JavaController class for a Java application:
+To use client support, your controllers must inherit from the JavaController class for a Java application:
 
     public class Application extends JavaController {
 
 or from the ScalaController trait for a Scala application:
 
     object Application extends ScalaController {
+
+
+### Define the supported clients
 
 All the clients you want to support must be registered when the application starts. You can do this by defining an eager loaded bean.
 
@@ -337,6 +341,47 @@ The latest release of the **play-pac4j** project is the **1.4.0** version:
 
 See the [release notes](https://github.com/pac4j/play-pac4j/wiki/Release-notes).
 
+## Migration instructions
+
+This section will contain migration instructions when necessary.
+
+### Migrating to play-pac4j 1.5.x
+
+Since Play 2.4, the Play framework is migrating to use dependency injection (by default implemented with Guice), so that we get rid of global objects and state. In order to keep play-pac4j in line with Play's strategy, there are a few changes which are outlined here.
+
+**Configuring the authentication clients**
+
+In earlier versions we made use of the Global object to configure the authentication clients. The code for play-pac4j can be moved to an eagerly loaded bean. See section [Define the supported clients](#Define the supported clients) to see how this is done now. At this point in time the configuration via the Global object will still work, but consider migrating to DI style.
+
+**Moving to dependency injection based routing**
+Play 2.4 advocates the use of dependency injection everywhere. They also made next to the static routes generator, a dynamic routes generator. This is enabled with the setting:
+
+    routesGenerator := InjectedRoutesGenerator
+
+in build.sbt.
+
+More details on the changes in Play 2.4 and the move to Dependency injection can be found in the [Play 2.4 migration guide](https://www.playframework.com/documentation/2.4.x/Migration24).
+
+The consequence of this is that for Scala you need class Controllers instead of objects and for Java that the methods of the controller cannot be static anymore.
+
+Therefore we have added new Controller classes to play-pac4j, containing the same functionality as the old ones, but these will support the dynamic routes generator. Also we used this opportunity to move to more specific names for these classes (JavaController and ScalaController are somewhat generic names).
+
+When your application moves to the dynamic routes generator, you need to use these new classes:
+
+<table>
+<tr><td>**old class**</td><td>**new class**</td></tr>
+<tr><td>org.pac4j.play.java.JavaController</td><td>org.pac4j.play.java.SecureController</td></tr>
+<tr><td>org.pac4j.play.scala.ScalaController</td><td>org.pac4j.play.scala.Security</td></tr>
+<tr><td>org.pac4j.play.CallbackController</td><td>org.pac4j.play.SecurityCallbackController</td></tr>
+</table>
+
+Note that for Scala the recommended way to use the trait is:
+
+    class MyController extends Controller with Security {
+      ... [your methods] ....
+    }
+
+The old classes will be supported for now, but are already deprecated to reflect our intentions that we want to follow the Play framework philosophy.
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ This library has **only 12 classes**:
 
 * the *Config* class gathers all the configuration
 * the *Constants* class gathers all the constants
-* the *CallbackController* class is used to finish the authentication process and logout the user
+* the *SecurityCallbackController* class is used to finish the authentication process and logout the user
 * the *StorageHelper* class deals with storing/retrieving data from the cache
 * the *JavaWebContext* class is a Java wrapper for the user request, response and session
-* the *JavaController* class is the Java controller to retrieve the user profile or the redirection url to start the authentication process
+* the *SecureController* class is the Java controller to retrieve the user profile or the redirection url to start the authentication process
 * the *RequiresAuthentication* annotation is to protect an action if the user is not authenticated and starts the authentication process if necessary
 * the *RequiresAuthenticationAction* class is the action to check if the user is not authenticated and starts the authentication process if necessary (the associated context is stored in the *ActionContext* class)
-* the *ScalaController* trait is the Scala controller to retrieve the user profile or the redirection url to start the authentication process
+* the *Security* trait is the Scala controller to retrieve the user profile or the redirection url to start the authentication process
 * the *ScalaWebContext* class is a Scala wrapper for the user request, response and session
 * the *PlayLogoutHandler* class is dedicated to CAS support to handle CAS logout request.
 

--- a/play-pac4j-java/src/main/java/org/pac4j/play/CallbackController.java
+++ b/play-pac4j-java/src/main/java/org/pac4j/play/CallbackController.java
@@ -33,10 +33,15 @@ import play.mvc.Result;
 /**
  * <p>This controller is the class to finish the authentication process and logout the user.</p>
  * <p>Public methods : {@link #callback()}, {@link #logoutAndOk()} and {@link #logoutAndRedirect()} must be used in the routes file.</p>
- * 
+ *
+ * @deprecated From Play 2.4 onwards, the Play framework will move to a complete Dependency Injection based
+ * framework. It is highly recommended to upgrade your project in this way. You cna use the new {@link SecurityCallbackController} to
+ * in your routes file. This controller will no longer be supported from play-pac4j-java 1.6.x and higher.
+ *
  * @author Jerome Leleu
  * @since 1.0.0
  */
+@Deprecated
 public class CallbackController extends Controller {
 
     protected static final Logger logger = LoggerFactory.getLogger(CallbackController.class);

--- a/play-pac4j-java/src/main/java/org/pac4j/play/SecurityCallbackController.java
+++ b/play-pac4j-java/src/main/java/org/pac4j/play/SecurityCallbackController.java
@@ -33,8 +33,8 @@ import java.util.Map;
  * <p>This controller is the class to finish the authentication process and logout the user.</p>
  * <p>Public methods : {@link #callback()}, {@link #logoutAndOk()} and {@link #logoutAndRedirect()} must be used in the routes file.</p>
  * 
- * @author Jerome Leleu
- * @since 1.0.0
+ * @author Hugo Valk
+ * @since 1.5.0
  */
 public class SecurityCallbackController extends Controller {
 

--- a/play-pac4j-java/src/main/java/org/pac4j/play/SecurityCallbackController.java
+++ b/play-pac4j-java/src/main/java/org/pac4j/play/SecurityCallbackController.java
@@ -1,0 +1,147 @@
+/*
+  Copyright 2012 - 2015 pac4j organization
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.pac4j.play;
+
+import org.apache.commons.lang3.StringUtils;
+import org.pac4j.core.context.Pac4jConstants;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.play.java.ActionContext;
+import org.pac4j.play.java.RequiresAuthenticationAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import play.libs.F.Function0;
+import play.libs.F.Promise;
+import play.mvc.Controller;
+import play.mvc.Result;
+
+import java.util.Map;
+
+/**
+ * <p>This controller is the class to finish the authentication process and logout the user.</p>
+ * <p>Public methods : {@link #callback()}, {@link #logoutAndOk()} and {@link #logoutAndRedirect()} must be used in the routes file.</p>
+ * 
+ * @author Jerome Leleu
+ * @since 1.0.0
+ */
+public class SecurityCallbackController extends Controller {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SecurityCallbackController.class);
+
+    private RequiresAuthenticationAction action = new RequiresAuthenticationAction() {
+
+        @Override
+        protected Promise<CommonProfile> retrieveUserProfile(ActionContext actionContext) {
+            return super.authenticate(actionContext);
+        }
+
+        @Override
+        protected Promise<Result> authenticationSuccess(CommonProfile profile, ActionContext actionContext) {
+            return redirectToTarget(actionContext);
+        }
+
+        @Override
+        protected Promise<Result> authenticationFailure(ActionContext actionContext) {
+            return redirectToTarget(actionContext);
+        }
+
+        private Promise<Result> redirectToTarget(final ActionContext actionContext) {
+            // retrieve saved request and redirect
+            return Promise.promise(new Function0<Result>() {
+                @Override
+                public Result apply() {
+                    return redirect(defaultUrl(retrieveOriginalUrl(actionContext), Config.getDefaultSuccessUrl()));
+                }
+            });
+        }
+
+    };
+
+    /**
+     * This method handles the callback call from the provider to finish the authentication process. The credentials and then the profile of
+     * the authenticated user is retrieved and the originally requested url (or the specific saved url) is restored.
+     * 
+     * @return the redirection to the saved request
+     */
+    public Promise<Result> callback() {
+
+        return action.call(ctx());
+
+    }
+
+    /**
+     * This method logouts the authenticated user.
+     */
+    private void logout() {
+        // get the session id
+        final String sessionId = session(Pac4jConstants.SESSION_ID);
+        LOGGER.debug("sessionId for logout : {}", sessionId);
+        if (StringUtils.isNotBlank(sessionId)) {
+            // remove user profile from cache
+            StorageHelper.removeProfile(sessionId);
+            LOGGER.debug("remove user profile for sessionId : {}", sessionId);
+        }
+        session().remove(Pac4jConstants.SESSION_ID);
+    }
+
+    /**
+     * This method logouts the authenticated user and send him to a blank page.
+     * 
+     * @return the redirection to the blank page
+     */
+    public Result logoutAndOk() {
+        logout();
+        return ok();
+    }
+
+    /**
+     * This method logouts the authenticated user and send him to the url defined in the
+     * {@link Constants#REDIRECT_URL_LOGOUT_PARAMETER_NAME} parameter name or to the <code>defaultLogoutUrl</code>.
+     * This parameter is matched against the {@link Config#getLogoutUrlPattern()}.
+     * 
+     * @return the redirection to the "logout url"
+     */
+    public Result logoutAndRedirect() {
+        logout();
+        // parameters in url
+        final Map<String, String[]> parameters = request().queryString();
+        final String[] values = parameters.get(Constants.REDIRECT_URL_LOGOUT_PARAMETER_NAME);
+        String value = null;
+        if (values != null && values.length == 1) {
+            String value0 = values[0];
+            // check the url pattern
+            if (Config.getLogoutUrlPattern().matcher(value0).matches()) {
+                value = value0;
+            }
+        }
+        return redirect(defaultUrl(value, Config.getDefaultLogoutUrl()));
+    }
+
+    /**
+     * This method returns the default url from a specified url compared with a default url.
+     * 
+     * @param url
+     * @param defaultUrl
+     * @return the default url
+     */
+    public String defaultUrl(final String url, final String defaultUrl) {
+        String redirectUrl = defaultUrl;
+        if (StringUtils.isNotBlank(url)) {
+            redirectUrl = url;
+        }
+        LOGGER.debug("defaultUrl : {}", redirectUrl);
+        return redirectUrl;
+    }
+}

--- a/play-pac4j-java/src/main/java/org/pac4j/play/java/JavaController.java
+++ b/play-pac4j-java/src/main/java/org/pac4j/play/java/JavaController.java
@@ -31,10 +31,15 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This controller is the Java controller to retrieve the user profile or the redirection url to start the authentication process.
- * 
+ *
+ * @deprecated From Play 2.4 onwards, the Play framework will move to a complete Dependency Injection based
+ * framework. It is highly recommended to upgrade your project in this way. You cna use the new {@link SecureController} to
+ * extend from. This controller will no longer be supported from play-pac4j-java 1.6.x and higher.
+ *
  * @author Jerome Leleu
  * @since 1.0.0
  */
+@Deprecated
 public class JavaController extends CallbackController {
 
     protected static final Logger logger = LoggerFactory.getLogger(JavaController.class);

--- a/play-pac4j-java/src/main/java/org/pac4j/play/java/SecureController.java
+++ b/play-pac4j-java/src/main/java/org/pac4j/play/java/SecureController.java
@@ -1,0 +1,91 @@
+package org.pac4j.play.java;
+
+import org.apache.commons.lang3.StringUtils;
+import org.pac4j.core.client.BaseClient;
+import org.pac4j.core.client.Clients;
+import org.pac4j.core.client.RedirectAction;
+import org.pac4j.core.context.Pac4jConstants;
+import org.pac4j.core.exception.RequiresHttpAction;
+import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.play.CallbackController;
+import org.pac4j.play.Config;
+import org.pac4j.play.SecurityCallbackController;
+import org.pac4j.play.StorageHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by hv01016 on 11-6-2015.
+ */
+public class SecureController extends SecurityCallbackController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JavaController.class);
+
+    /**
+     * This method returns the url of the provider where the user must be redirected for authentication.
+     * The current requested url is saved into session to be restored after authentication.
+     *
+     * @param clientName
+     * @return the url of the provider where to redirect the user
+     */
+    protected RedirectAction getRedirectAction(final String clientName) {
+        return getRedirectAction(clientName, null);
+    }
+
+    /**
+     * This method returns the url of the provider where the user must be redirected for authentication.
+     * The input <code>targetUrl</code> (or the current requested url if <code>null</code>) is saved into session to be restored after
+     * authentication.
+     *
+     * @param clientName
+     * @param targetUrl
+     * @return the url of the provider where to redirect the user
+     */
+    protected RedirectAction getRedirectAction(final String clientName, final String targetUrl) {
+        // get or create session id
+        String sessionId = StorageHelper.getOrCreationSessionId(session());
+        // requested url to save
+        final String requestedUrlToSave = CallbackController.defaultUrl(targetUrl, request().uri());
+        LOGGER.debug("requestedUrlToSave : {}", requestedUrlToSave);
+        StorageHelper.saveRequestedUrl(sessionId, clientName, requestedUrlToSave);
+        // clients
+        Clients clients = Config.getClients();
+        // no clients -> misconfiguration ?
+        if (clients == null) {
+            throw new TechnicalException("No client defined. Use Config.setClients(clients)");
+        }
+        // redirect to the provider for authentication
+        JavaWebContext webContext = new JavaWebContext(request(), response(), session());
+        RedirectAction action = null;
+        try {
+            action = ((BaseClient) clients.findClient(clientName)).getRedirectAction(webContext, false, false);
+        } catch (RequiresHttpAction e) {
+            // should not happen
+        }
+        LOGGER.debug("redirectAction : {}", action);
+        return action;
+    }
+
+    /**
+     * This method returns the user profile if the user is authenticated or <code>null</code> otherwise.
+     *
+     * @return the user profile if the user is authenticated or <code>null</code> otherwise
+     */
+    protected CommonProfile getUserProfile() {
+        // get the session id
+        final String sessionId = session(Pac4jConstants.SESSION_ID);
+        LOGGER.debug("sessionId for profile : {}", sessionId);
+        CommonProfile profile = null;
+        if (StringUtils.isNotBlank(sessionId)) {
+            // get the user profile
+            profile = StorageHelper.getProfile(sessionId);
+        }
+        if (profile == null) {
+            // Try to get the User Profile from the current request (stateless flow)
+            return (CommonProfile) ctx().args.get(Pac4jConstants.USER_PROFILE);
+        } else {
+            return profile;
+        }
+    }
+}

--- a/play-pac4j-java/src/main/java/org/pac4j/play/java/SecureController.java
+++ b/play-pac4j-java/src/main/java/org/pac4j/play/java/SecureController.java
@@ -16,7 +16,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Created by hv01016 on 11-6-2015.
+ * This controller is the Java controller to retrieve the user profile or the redirection url to start the authentication process.
+ *
+ * @author Hugo Valk
+ * @since 1.5.0
  */
 public class SecureController extends SecurityCallbackController {
 

--- a/play-pac4j-scala_2.11/src/main/scala/org/pac4j/play/scala/ScalaController.scala
+++ b/play-pac4j-scala_2.11/src/main/scala/org/pac4j/play/scala/ScalaController.scala
@@ -31,9 +31,14 @@ import org.pac4j.core.exception._
 /**
  * This controller is the Scala controller to retrieve the user profile or the redirection url to start the authentication process.
  *
+ * @deprecated From Play 2.4 onwards, the Play framework will move to a complete Dependency Injection based
+ * framework. It is highly recommended to upgrade your project in this way. You cna use the new {@link Security} trait to
+ * to mix the security capabilities in your controllers. This controller will no longer be supported from play-pac4j-java 1.6.x and higher. 
+ *
  * @author Jerome Leleu
  * @since 1.0.0
  */
+@Deprecated
 trait ScalaController[P<:CommonProfile] extends Controller {
 
   protected val logger = LoggerFactory.getLogger("org.pac4j.play.scala.ScalaController")

--- a/play-pac4j-scala_2.11/src/main/scala/org/pac4j/play/scala/Security.scala
+++ b/play-pac4j-scala_2.11/src/main/scala/org/pac4j/play/scala/Security.scala
@@ -1,0 +1,177 @@
+/*
+  Copyright 2012 - 2015 pac4j organization
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.pac4j.play.scala
+
+import org.pac4j.core.client._
+import org.pac4j.core.context._
+import org.pac4j.core.exception._
+import org.pac4j.core.profile._
+import play.api.mvc._
+
+import scala.concurrent.Future
+import org.pac4j.play._
+import org.slf4j._
+
+/**
+ * This trait adds security features to your Scala controllers.
+ *
+ * One can retrieve the user profile or the redirection url to start the authentication process.
+ *
+ * @author Jerome Leleu
+ * @since 1.0.0
+ */
+trait Security[P<:CommonProfile] extends Controller {
+
+  private val logger = LoggerFactory.getLogger("org.pac4j.play.scala.Security")
+
+  /**
+   * Get or create a new sessionId.
+   *
+   * @param request
+   * @return the (updated) session
+   */
+  protected def getOrCreateSessionId(request: RequestHeader): Session = {
+    var newSession = request.session
+    val optionSessionId = newSession.get(Pac4jConstants.SESSION_ID)
+    logger.debug("getOrCreateSessionId : {}", optionSessionId)
+    if (!optionSessionId.isDefined) {
+      newSession += Pac4jConstants.SESSION_ID -> StorageHelper.generateSessionId()
+    }
+    newSession
+  }
+
+  /**
+   * Defines an action with requires authentication : it means that the user is redirected to the provider
+   * if he is not authenticated or access directly to the action otherwise.
+   *
+   * @param clientName
+   * @param targetUrl
+   * @param parser
+   * @param isAjax
+   * @param action
+   * @return the current action to process or the redirection to the provider if the user is not authenticated
+   */
+  protected def RequiresAuthentication[A](clientName: String, targetUrl: String, parser: BodyParser[A], isAjax: Boolean)(action: P => Action[A]) = Action.async(parser) { request =>
+    logger.debug("Entering RequiresAuthentication")
+    var newSession = getOrCreateSessionId(request)
+    val sessionId = newSession.get(Pac4jConstants.SESSION_ID).get
+    logger.debug("sessionId : {}", sessionId)
+    val profile = getUserProfile(request)
+    logger.debug("profile : {}", profile)
+
+    if (profile == null) {
+      try {
+        val redirectAction = getRedirectAction(request, newSession, clientName, targetUrl, true, isAjax)
+        logger.debug("redirectAction : {}", redirectAction)
+        redirectAction.getType() match {
+          case RedirectAction.RedirectType.REDIRECT => Future.successful(Redirect(redirectAction.getLocation()).withSession(newSession))
+          case RedirectAction.RedirectType.SUCCESS => Future.successful(Ok(redirectAction.getContent()).withSession(newSession).as(HTML))
+          case _ => throw new TechnicalException("Unexpected RedirectAction : " + redirectAction.getType)
+        }
+      } catch {
+        case ex: RequiresHttpAction => {
+          val code = ex.getCode()
+          if (code == 401) {
+            Future.successful(Unauthorized(BaseConfig.getErrorPage401()).as(HTML))
+          } else if (code == 403) {
+            Future.successful(Forbidden(BaseConfig.getErrorPage403()).as(HTML))
+          } else {
+            throw new TechnicalException("Unexpected HTTP code : " + code)
+          }
+        }
+      }
+    } else {
+      action(profile)(request)
+    }
+  }
+
+  protected def RequiresAuthentication(clientName: String, targetUrl: String = "", isAjax: Boolean = false)(action: P => Action[AnyContent]): Action[AnyContent] = {
+    RequiresAuthentication(clientName, targetUrl, parse.anyContent, isAjax)(action)
+  }
+
+  /**
+   * Returns the redirection action to the provider for authentication.
+   *
+   * @param request
+   * @param newSession
+   * @param clientName
+   * @param targetUrl
+   * @return the redirection url to the provider
+   */
+  protected def getRedirectAction[A](request: Request[A], newSession: Session, clientName: String, targetUrl: String = ""): RedirectAction = {
+    var action: RedirectAction = null
+    try {
+      // redirect to the provider for authentication
+      action = getRedirectAction(request, newSession, clientName, targetUrl, false, false)
+    } catch {
+      case ex: RequiresHttpAction => {
+        // should not happen
+      }
+    }
+    logger.debug("redirectAction to : {}", action)
+    action
+  }
+
+  /**
+   * Returns the redirection action to the provider for authentication.
+   *
+   * @param request
+   * @param newSession
+   * @param clientName
+   * @param targetUrl
+   * @param protectedPage
+   * @param isAjax
+   * @return the redirection url to the provider
+   */
+  private def getRedirectAction[A](request: Request[A], newSession: Session, clientName: String, targetUrl: String, protectedPage: Boolean, isAjax: Boolean): RedirectAction = {
+    val sessionId = newSession.get(Pac4jConstants.SESSION_ID).get
+    logger.debug("sessionId for getRedirectionUrl() : {}", sessionId)
+    // save requested url to save
+    val requestedUrlToSave = CallbackController.defaultUrl(targetUrl, request.uri)
+    logger.debug("requestedUrlToSave : {}", requestedUrlToSave)
+    StorageHelper.saveRequestedUrl(sessionId, clientName, requestedUrlToSave);
+    // context
+    val scalaWebContext = new ScalaWebContext(request, newSession)
+    // clients
+    val clients = Config.getClients()
+    if (clients == null) {
+      throw new TechnicalException("No client defined. Use Config.setClients(clients)")
+    }
+    val client = clients.findClient(clientName) match { case c: BaseClient[_, _] => c }
+    val action = client.getRedirectAction(scalaWebContext, protectedPage, isAjax)
+    logger.debug("redirectAction to : {}", action)
+    action
+  }
+
+  /**
+   * Returns the user profile.
+   *
+   * @param request
+   * @return the user profile
+   */
+  protected def getUserProfile(request: RequestHeader): P = {
+    // get the session id
+    var profile = null.asInstanceOf[P]
+    val sessionId = request.session.get(Pac4jConstants.SESSION_ID)
+    logger.debug("sessionId for profile : {}", sessionId)
+    if (sessionId.isDefined) {
+      // get the user profile
+      profile = StorageHelper.getProfile(sessionId.get).asInstanceOf[P]
+      logger.debug("profile : {}", profile)
+    }
+    profile
+  }
+}

--- a/play-pac4j-scala_2.11/src/main/scala/org/pac4j/play/scala/Security.scala
+++ b/play-pac4j-scala_2.11/src/main/scala/org/pac4j/play/scala/Security.scala
@@ -30,8 +30,8 @@ import org.slf4j._
  *
  * One can retrieve the user profile or the redirection url to start the authentication process.
  *
- * @author Jerome Leleu
- * @since 1.0.0
+ * @author Hugo Valk
+ * @since 1.5.0
  */
 trait Security[P<:CommonProfile] extends Controller {
 


### PR DESCRIPTION
This pull request contains support for the new Play 2.4 dynamic routes generator. 
I've added a few new classes that support this new behavior, so the old ones can be used in existing application that do not want to move to the dynamic routes generator yet. 

I also took the opportunity to use more descriptive names for the new classes:
JavaController -> SecureController
ScalaController -> Security, so it can be used like:

    class Application extends Controller with Security

CallbackController -> SecurityCallbackController

Let me know what you think. I can also update the demo projects, once this pull request is accepted. 