### PR TITLE
Multiple code improvements: squid:S1155, squid:S2293

### DIFF
--- a/src/main/java/org/pac4j/play/PlayWebContext.java
+++ b/src/main/java/org/pac4j/play/PlayWebContext.java
@@ -127,10 +127,10 @@ public class PlayWebContext extends BaseResponseContext {
         if (body != null) {
             formParameters = body.asFormUrlEncoded();
         } else {
-            formParameters = new HashMap<String, String[]>();
+            formParameters = new HashMap<>();
         }
         final Map<String, String[]> urlParameters = request.queryString();
-        final Map<String, String[]> parameters = new HashMap<String, String[]>();
+        final Map<String, String[]> parameters = new HashMap<>();
         if (formParameters != null) {
             parameters.putAll(formParameters);
         }

--- a/src/main/java/org/pac4j/play/java/RequiresAuthenticationAction.java
+++ b/src/main/java/org/pac4j/play/java/RequiresAuthenticationAction.java
@@ -103,7 +103,7 @@ public class RequiresAuthenticationAction extends AbstractConfigAction {
             logger.debug("profile: {}", profile);
 
             // no profile and some current clients
-            if (profile == null && currentClients != null && currentClients.size() > 0) {
+            if (profile == null && currentClients != null && !currentClients.isEmpty()) {
                 // loop on all clients searching direct ones to perform authentication
                 for (final Client currentClient : currentClients) {
                     if (currentClient instanceof DirectClient) {
@@ -161,7 +161,7 @@ public class RequiresAuthenticationAction extends AbstractConfigAction {
     }
 
     protected boolean useSession(final WebContext context, final List<Client> currentClients) {
-        return currentClients == null || currentClients.size() == 0 || currentClients.get(0) instanceof IndirectClient;
+        return currentClients == null || currentClients.isEmpty() || currentClients.get(0) instanceof IndirectClient;
     }
 
     protected Promise<Result> forbidden(final PlayWebContext context, final List<Client> currentClients, final UserProfile profile) {
@@ -169,7 +169,7 @@ public class RequiresAuthenticationAction extends AbstractConfigAction {
     }
 
     protected boolean startAuthentication(final PlayWebContext context, final List<Client> currentClients) {
-        return currentClients != null && currentClients.size() > 0 && currentClients.get(0) instanceof IndirectClient;
+        return currentClients != null && !currentClients.isEmpty() && currentClients.get(0) instanceof IndirectClient;
     }
 
     protected void saveRequestedUrl(final WebContext context, final List<Client> currentClients) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1155 Collection.isEmpty() should be used to test for emptiness.
squid:S2293 The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2293
Please let me know if you have any questions.
George Kankava