### PR TITLE
get location form the play context, update play version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
     <properties>
         <pac4j.version>1.8.8</pac4j.version>
-        <play.version>2.5.1</play.version>
+        <play.version>2.5.3</play.version>
         <powermock.version>1.6.4</powermock.version>
     </properties>
 

--- a/src/main/java/org/pac4j/play/http/DefaultHttpActionAdapter.java
+++ b/src/main/java/org/pac4j/play/http/DefaultHttpActionAdapter.java
@@ -15,6 +15,8 @@
  */
 package org.pac4j.play.http;
 
+import java.util.Map;
+
 import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.TechnicalException;
@@ -22,6 +24,9 @@ import org.pac4j.core.http.HttpActionAdapter;
 import org.pac4j.play.PlayWebContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import play.mvc.Http.Context;
+import play.mvc.Http.Response;
 
 import static play.mvc.Results.*;
 
@@ -44,7 +49,7 @@ public class DefaultHttpActionAdapter implements HttpActionAdapter {
         } else if (code == HttpConstants.FORBIDDEN) {
             return forbidden("forbidden");
         } else if (code == HttpConstants.TEMP_REDIRECT) {
-            return redirect(webContext.getResponseLocation());
+            return redirect(getLocation(webContext));
         } else if (code == HttpConstants.OK) {
             final String content = webContext.getResponseContent();
             logger.debug("render: {}", content);
@@ -53,5 +58,13 @@ public class DefaultHttpActionAdapter implements HttpActionAdapter {
         final String message = "Unsupported HTTP action: " + code;
         logger.error(message);
         throw new TechnicalException(message);
+    }
+
+    private String getLocation(final PlayWebContext webContext){
+      final Context context = webContext.getJavaContext();
+      final Response response = context.response();
+      final Map<String, String> headers = response.getHeaders();
+
+      return headers.get(HttpConstants.LOCATION_HEADER);
     }
 }

--- a/src/test/java/org/pac4j/play/http/DefaultHttpActionAdapterTest.java
+++ b/src/test/java/org/pac4j/play/http/DefaultHttpActionAdapterTest.java
@@ -15,6 +15,8 @@
  */
 package org.pac4j.play.http;
 
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -65,6 +67,14 @@ public class DefaultHttpActionAdapterTest {
 	public final void testAdaptRedirect() {
 		// given
 		PlayWebContext playWebContext = mock(PlayWebContext.class);
+		play.mvc.Http.Response response = mock(play.mvc.Http.Response.class);
+		play.mvc.Http.Context context = mock( play.mvc.Http.Context.class);
+		Map<String, String> headers = response.getHeaders();
+		headers.put(HttpConstants.LOCATION_HEADER, "/loginForm");
+		
+		doReturn(headers).when(response).getHeaders();
+		doReturn(response).when(context).response();
+		doReturn(context).when(playWebContext).getJavaContext();
 		
 		// when
 		Object result = defaultHttpActionAdapter.adapt(HttpConstants.TEMP_REDIRECT, playWebContext);


### PR DESCRIPTION
The `java.lang.NullPointerException` exception is throwing starting from the **Play 2.5.3**. 

So I update the play version. 

It is workable for **Play 2.5.0**, **Play 2.5.1** and **Play 2.5.2** as well.