### PR TITLE
Session cookies in Play have max-age set to `null` (2.3.x)

### DIFF
--- a/src/main/java/org/pac4j/play/PlayWebContext.java
+++ b/src/main/java/org/pac4j/play/PlayWebContext.java
@@ -236,14 +236,13 @@ public class PlayWebContext implements WebContext {
 
     @Override
     public void addResponseCookie(final Cookie cookie) {
-        response.setCookie(new Http.Cookie(
-            cookie.getName(),
+        response.setCookie(cookie.getName(),
             cookie.getValue(),
             cookie.getMaxAge() == -1 ? null : cookie.getMaxAge(),
             cookie.getPath(),
             cookie.getDomain(),
             cookie.isSecure(),
-            cookie.isHttpOnly()));
+            cookie.isHttpOnly());
     }
 
     @Override

--- a/src/main/java/org/pac4j/play/PlayWebContext.java
+++ b/src/main/java/org/pac4j/play/PlayWebContext.java
@@ -236,8 +236,14 @@ public class PlayWebContext implements WebContext {
 
     @Override
     public void addResponseCookie(final Cookie cookie) {
-        response.setCookie(cookie.getName(), cookie.getValue(), cookie.getMaxAge(), cookie.getPath(),
-                cookie.getDomain(), cookie.isSecure(), cookie.isHttpOnly());
+        response.setCookie(new Http.Cookie(
+            cookie.getName(),
+            cookie.getValue(),
+            cookie.getMaxAge() == -1 ? null : cookie.getMaxAge(),
+            cookie.getPath(),
+            cookie.getDomain(),
+            cookie.isSecure(),
+            cookie.isHttpOnly()));
     }
 
     @Override


### PR DESCRIPTION
Fixes for #135, for 2.3.x.

Also changed to `setCookie(Http.Cookie)` as the old method is deprecated.