### PR TITLE
Put the current profile to the Http.Context for template access

### DIFF
--- a/src/main/java/org/pac4j/play/java/ProfileToContext.java
+++ b/src/main/java/org/pac4j/play/java/ProfileToContext.java
@@ -1,0 +1,22 @@
+package org.pac4j.play.java;
+
+import play.mvc.With;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used for the {@link ProfileToContextAction}.
+ *
+ * @author Sebastian Hardt (s.hardt@micromata.de)
+ */
+@With(ProfileToContextAction.class)
+@Target({ ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ProfileToContext
+{
+}

--- a/src/main/java/org/pac4j/play/java/ProfileToContextAction.java
+++ b/src/main/java/org/pac4j/play/java/ProfileToContextAction.java
@@ -1,0 +1,89 @@
+package org.pac4j.play.java;
+
+import com.google.inject.Inject;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.ProfileManager;
+import org.pac4j.play.PlayWebContext;
+import org.pac4j.play.store.PlaySessionStore;
+import play.mvc.Action;
+import play.mvc.Http;
+import play.mvc.Result;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Before CDI you could easily call statically a function from the template engine to access the current user/profile.
+ * With CDI there is no way to access the session store by injecting it directly into the the template via CDI.
+ * The only way to do this is to pass it as an argument to the template itself, which can be annoying when yo need the profile in an main.tpl for exp. which is called from the other template.
+ *
+ * <code>
+ * @(profile: CommonProfile)
+ *
+ * ...
+ * @main(profile) {
+ *   <h1>Hello</h1>
+ * }
+ * ...
+ * </code>
+ *
+ *
+ * Just annotate your controller with the {@link ProfileToContext} annotation and you have the profile in the CTX.
+ *
+ * <code>
+ *   @UserToContextAnnotation
+ *    public class UserToContextController extends Controller {
+ *      ...
+ *    }
+ * </code>
+ *
+ * You can access the Optional for the profile from the template with the following code:
+ * <code>
+ *   @import Http.Context
+ *   @currentUserOptional = @{Context.current().args.get(org.pac4j.play.java.UserToContextAction.CONTEXT_CURRENT_PROFILE_KEY).asInstanceOf[java.util.Optional[org.pac4j.core.profile.CommonProfile]]}
+ *   @if(currentUserOptional.isEmpty == false) {
+ *     Hello: @currentUserOptional.get().getUsername
+ *   }
+ *
+ * </code>
+ *
+ * @author Sebastian Hardt (s.hardt@micromata.de)
+ */
+public class ProfileToContextAction extends Action<ProfileToContext>
+{
+
+  /**
+   * The current key for the user.
+   */
+  public static final String CONTEXT_CURRENT_PROFILE_KEY = "pac4j-currentProfile";
+
+  /**
+   * The session store of the play application.
+   */
+  private final PlaySessionStore playSessionStore;
+
+  @Inject
+  public ProfileToContextAction(final PlaySessionStore playSessionStore) {
+    this.playSessionStore = playSessionStore;
+  }
+
+  @Override
+  public CompletionStage<Result> call(Http.Context ctx)
+  {
+    Optional<CommonProfile> userProfile = getUserProfile(ctx,playSessionStore);
+    ctx.args.put(CONTEXT_CURRENT_PROFILE_KEY,userProfile);
+    return delegate.call(ctx);
+  }
+
+  /**
+   * Gets the current user profile from the session store.
+   * @param ctx the http context.
+   * @return the {@link Optional}
+   */
+  public static Optional<CommonProfile> getUserProfile(Http.Context ctx,final PlaySessionStore playSessionStore) {
+    PlayWebContext webContext = new PlayWebContext(ctx,playSessionStore );
+    ProfileManager<CommonProfile> profileManager = new ProfileManager(webContext);
+    Optional<CommonProfile> profile = profileManager.get(true);
+    return profile;
+  }
+}

--- a/src/main/java/org/pac4j/play/java/ProfileToContextAction.java
+++ b/src/main/java/org/pac4j/play/java/ProfileToContextAction.java
@@ -18,15 +18,15 @@ import java.util.concurrent.CompletionStage;
  * The only way to do this is to pass it as an argument to the template itself, which can be annoying when yo need the profile in an main.tpl for exp. which is called from the other template.
  *
  * <pre>
- * <code>
- * {@literal@}(profile: CommonProfile)
+ * {@code
+ * @literal@}(profile: CommonProfile)
  *
  * ...
  * {@literal@}main(profile) {
  *   <h1>Hello</h1>
  * }
  * ...
- * </code>
+ * }
  * </pre>
  *
  *

--- a/src/main/java/org/pac4j/play/java/ProfileToContextAction.java
+++ b/src/main/java/org/pac4j/play/java/ProfileToContextAction.java
@@ -17,35 +17,42 @@ import java.util.concurrent.CompletionStage;
  * With CDI there is no way to access the session store by injecting it directly into the the template via CDI.
  * The only way to do this is to pass it as an argument to the template itself, which can be annoying when yo need the profile in an main.tpl for exp. which is called from the other template.
  *
+ * <pre>
  * <code>
- * @(profile: CommonProfile)
+ * {@literal@}(profile: CommonProfile)
  *
  * ...
- * @main(profile) {
+ * {@literal@}main(profile) {
  *   <h1>Hello</h1>
  * }
  * ...
  * </code>
+ * </pre>
  *
  *
  * Just annotate your controller with the {@link ProfileToContext} annotation and you have the profile in the CTX.
  *
+ * <pre>
  * <code>
- *   @UserToContextAnnotation
+ *   {@literal@}UserToContextAnnotation
  *    public class UserToContextController extends Controller {
  *      ...
  *    }
  * </code>
+ * </pre>
  *
  * You can access the Optional for the profile from the template with the following code:
+ *
+ * <pre>
  * <code>
- *   @import Http.Context
- *   @currentUserOptional = @{Context.current().args.get(org.pac4j.play.java.UserToContextAction.CONTEXT_CURRENT_PROFILE_KEY).asInstanceOf[java.util.Optional[org.pac4j.core.profile.CommonProfile]]}
- *   @if(currentUserOptional.isEmpty == false) {
+ *   {@literal@}import Http.Context
+ *   {@literal@}currentUserOptional = @{Context.current().args.get(org.pac4j.play.java.UserToContextAction.CONTEXT_CURRENT_PROFILE_KEY).asInstanceOf[java.util.Optional[org.pac4j.core.profile.CommonProfile]]}
+ *   {@literal@}(currentUserOptional.isEmpty == false) {
  *     Hello: @currentUserOptional.get().getUsername
  *   }
  *
  * </code>
+ * </pre>
  *
  * @author Sebastian Hardt (s.hardt@micromata.de)
  */
@@ -63,25 +70,28 @@ public class ProfileToContextAction extends Action<ProfileToContext>
   private final PlaySessionStore playSessionStore;
 
   @Inject
-  public ProfileToContextAction(final PlaySessionStore playSessionStore) {
+  public ProfileToContextAction(final PlaySessionStore playSessionStore)
+  {
     this.playSessionStore = playSessionStore;
   }
 
   @Override
   public CompletionStage<Result> call(Http.Context ctx)
   {
-    Optional<CommonProfile> userProfile = getUserProfile(ctx,playSessionStore);
-    ctx.args.put(CONTEXT_CURRENT_PROFILE_KEY,userProfile);
+    Optional<CommonProfile> userProfile = getUserProfile(ctx, playSessionStore);
+    ctx.args.put(CONTEXT_CURRENT_PROFILE_KEY, userProfile);
     return delegate.call(ctx);
   }
 
   /**
    * Gets the current user profile from the session store.
+   *
    * @param ctx the http context.
    * @return the {@link Optional}
    */
-  public static Optional<CommonProfile> getUserProfile(Http.Context ctx,final PlaySessionStore playSessionStore) {
-    PlayWebContext webContext = new PlayWebContext(ctx,playSessionStore );
+  public static Optional<CommonProfile> getUserProfile(Http.Context ctx, final PlaySessionStore playSessionStore)
+  {
+    PlayWebContext webContext = new PlayWebContext(ctx, playSessionStore);
     ProfileManager<CommonProfile> profileManager = new ProfileManager(webContext);
     Optional<CommonProfile> profile = profileManager.get(true);
     return profile;

--- a/src/main/java/org/pac4j/play/java/ProfileToContextAction.java
+++ b/src/main/java/org/pac4j/play/java/ProfileToContextAction.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletionStage;
  *
  * <pre>
  * {@code
- * @literal@}(profile: CommonProfile)
+ * {@literal@}(profile: CommonProfile)
  *
  * ...
  * {@literal@}main(profile) {
@@ -33,25 +33,24 @@ import java.util.concurrent.CompletionStage;
  * Just annotate your controller with the {@link ProfileToContext} annotation and you have the profile in the CTX.
  *
  * <pre>
- * <code>
+ * {@code
  *   {@literal@}UserToContextAnnotation
  *    public class UserToContextController extends Controller {
  *      ...
  *    }
- * </code>
+ * }
  * </pre>
  *
  * You can access the Optional for the profile from the template with the following code:
  *
  * <pre>
- * <code>
+ * {@code
  *   {@literal@}import Http.Context
  *   {@literal@}currentUserOptional = @{Context.current().args.get(org.pac4j.play.java.UserToContextAction.CONTEXT_CURRENT_PROFILE_KEY).asInstanceOf[java.util.Optional[org.pac4j.core.profile.CommonProfile]]}
  *   {@literal@}(currentUserOptional.isEmpty == false) {
  *     Hello: @currentUserOptional.get().getUsername
  *   }
- *
- * </code>
+ * }
  * </pre>
  *
  * @author Sebastian Hardt (s.hardt@micromata.de)


### PR DESCRIPTION
Since CDI it is not possible to access the userprofile in a template directly because you need stuff which is handled via injection.

I worte this annotation which puts if avaible the userprofile into the Http.Context so you can access it from a template.