### PR TITLE
PlayCookieStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Notice that you can also configure a specific `HttpActionAdapter` to handle spec
 
 You can also define a specific `SecurityLogic` via the `setSecurityLogic` method.
 
+In addition to the `PlayCacheStore`, the `play-pac4j` project allows you the option to store your session into the native Play Session Cookie with the `PlayCookieStore`. Since this method uses encryption to secure the session inside the cookie, it is likely less efficient for some solutions. However, in cases where you want to preserve Play's statelessness, you can opt to use it instead of the `PlayCacheStore`.
+
 If you choose to use the `PlayCookieStore` instead of the `PlayCacheStore`, you'll need to replace this line:
 
 *Java:*
@@ -159,7 +161,7 @@ If you choose to use the `PlayCookieStore` instead of the `PlayCacheStore`, you'
 
 `bind(classOf[PlaySessionStore]).to(classOf[PlayCacheStore])`
 
-with a configured instance of PlayCookieStore, like this:
+with an instance of `PlayCookieStore` with an `EncryptionConfiguration`, like this:
 
 *Java:*
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,31 @@ Notice that you can also configure a specific `HttpActionAdapter` to handle spec
 
 You can also define a specific `SecurityLogic` via the `setSecurityLogic` method.
 
+If you choose to use the `PlayCookieStore` instead of the `PlayCacheStore`, you'll need to replace this line:
+
+*Java:*
+
+`bind(PlaySessionStore.class).to(PlayCacheStore.class);`
+
+*Scala:*
+
+`bind(classOf[PlaySessionStore]).to(classOf[PlayCacheStore])`
+
+with a configured instance of PlayCookieStore, like this:
+
+*Java:*
+
+```java
+PlayCookieStore playCookieStore = new PlayCookieStore(new SecretEncryptionConfiguration("YourSecretHere"));
+bind(PlaySessionStore.class).toInstance(playCookieStore);
+```
+*Scala:*
+
+```scala
+val playCookieStore = new PlayCookieStore(new SecretEncryptionConfiguration("YourSecretHere"))
+bind(classOf[PlaySessionStore]).toInstance(playCookieStore)
+```
+
 ---
 
 ### 3a) Protect urls per Action (`Secure`)

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.pac4j</groupId>
+            <artifactId>pac4j-jwt</artifactId>
+            <version>${pac4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.typesafe.play</groupId>
             <artifactId>play_2.11</artifactId>
             <version>${play.version}</version>

--- a/src/main/java/org/pac4j/play/store/PlayCookieStore.java
+++ b/src/main/java/org/pac4j/play/store/PlayCookieStore.java
@@ -14,101 +14,126 @@ import org.pac4j.jwt.credentials.authenticator.JwtAuthenticator;
 import org.pac4j.jwt.profile.JwtGenerator;
 import org.pac4j.jwt.JwtClaims;
 import org.pac4j.jwt.config.encryption.SecretEncryptionConfiguration;
-import org.pac4j.jwt.config.signature.SecretSignatureConfiguration;
 import com.google.inject.Inject;
 
 import play.cache.CacheApi;
 import play.mvc.Http;
 
+/**
+ * The Cookie storage uses an encrypted JWT inside the Play Session cookie for
+ * storage, allowing for a stateless backend.
+ * 
+ * The optional cache uses Play's native CacheApi as a performance boost. If the
+ * cache is enabled, it still falls back to the JWT in cases where the two
+ * disagree.
+ * 
+ * @author Nolan Barth
+ * @since 2.6.2
+ */
 public class PlayCookieStore implements PlaySessionStore {
-	
+
 	private static final Logger logger = LoggerFactory.getLogger(PlayCookieStore.class);
 
-    private final static String SEPARATOR = "$";
+	private final static String SEPARATOR = "$";
 
-    // prefix for the cache
-    private String prefix = "";
+	// prefix for the cache
+	private String prefix = "";
 
-    // 1 hour = 3600 seconds
-    private int timeout = 3600;
-    
-    private static boolean useCache = false;
-    private static SecretSignatureConfiguration secretSignatureConfig;
-    private static SecretEncryptionConfiguration secretEncryptConfig;
-    private JwtAuthenticator jwtAuthenticator;
-    private JwtGenerator<CommonProfile> jwtGenerator;
-    private final CacheApi cache;
-    
+	// 1 hour = 3600 seconds
+	private int timeout = 3600;
+
+	private boolean useCache = false;
+	private JwtAuthenticator jwtAuthenticator;
+	private JwtGenerator<CommonProfile> jwtGenerator;
+	private final CacheApi cache;
+
 	@Inject
-	public PlayCookieStore(final CacheApi cache) {
+	public PlayCookieStore(final CacheApi cache, final SecretEncryptionConfiguration secretEncryptConfig) {
 		super();
-		this.jwtAuthenticator = new JwtAuthenticator(secretSignatureConfig, secretEncryptConfig);
-		this.jwtGenerator = new JwtGenerator<CommonProfile>(secretSignatureConfig, secretEncryptConfig);
+		this.jwtAuthenticator = new JwtAuthenticator();
+		this.jwtAuthenticator.addEncryptionConfiguration(secretEncryptConfig);
+		this.jwtGenerator = new JwtGenerator<CommonProfile>();
+		this.jwtGenerator.setEncryptionConfiguration(secretEncryptConfig);
 		this.cache = cache;
 	}
 
 	String getKey(final String sessionId, final String key) {
-        return prefix + SEPARATOR + sessionId + SEPARATOR + key;
-    }
+		return prefix + SEPARATOR + sessionId + SEPARATOR + key;
+	}
 
-    @Override
-    public String getOrCreateSessionId(final PlayWebContext context) {
-        final Http.Session session = context.getJavaSession();
-        // get current sessionId
-        String sessionId = session.get(Pac4jConstants.SESSION_ID);
-        logger.trace("retrieved sessionId: {}", sessionId);
-        // if null, generate a new one
-        if (sessionId == null) {
-            // generate id for session
-            sessionId = java.util.UUID.randomUUID().toString();
-            logger.debug("generated sessionId: {}", sessionId);
-            // and save it to session
-            session.put(Pac4jConstants.SESSION_ID, sessionId);
-        }
-        return sessionId;
-    }
-	
+	@Override
+	public String getOrCreateSessionId(final PlayWebContext context) {
+		final Http.Session session = context.getJavaSession();
+		// get current sessionId
+		String sessionId = session.get(Pac4jConstants.SESSION_ID);
+		logger.trace("retrieved sessionId: {}", sessionId);
+		// if null, generate a new one
+		if (sessionId == null) {
+			// generate id for session
+			sessionId = java.util.UUID.randomUUID().toString();
+			logger.debug("generated sessionId: {}", sessionId);
+			// and save it to session
+			session.put(Pac4jConstants.SESSION_ID, sessionId);
+		}
+		return sessionId;
+	}
+
 	private String getSessionToken(final PlayWebContext context, String sessionId) {
 		final Http.Session session = context.getJavaSession();
-        // get current sessionToken using sessionId
-        String sessionToken = session.get(sessionId);
-        logger.trace("retrieved sessionToken: {}", sessionToken);
-        return sessionToken;
+		// get current sessionToken using sessionId
+		String sessionToken = session.get(sessionId);
+		logger.trace("retrieved sessionToken: {}", sessionToken);
+		return sessionToken;
 	}
-	
+
 	private void setSessionToken(final PlayWebContext context, String sessionId, Map<String, Object> sessionMap) {
 		final Http.Session session = context.getJavaSession();
-		//save the session as a JWT, replacing the previous instance if necessary.
-		if(session.containsKey(sessionId))
+		// save the session as a JWT, replacing the previous instance if
+		// necessary.
+		if (session.containsKey(sessionId))
 			session.remove(sessionId);
 		final String sessionToken = jwtGenerator.generate(sessionMap);
 		session.put(sessionId, sessionToken);
-		if(useCache) {
-			cache.set(getKey(sessionId, "MapCache"), sessionMap);
-			cache.set(getKey(sessionId, "TokenCache"), sessionToken);
-		}
+		if (useCache)
+			updateCache(sessionId, sessionToken, sessionMap);
 	}
-	
-	private Map<String, Object> getOrCreateSessionMap(final PlayWebContext context, String sessionId){
+
+	private void updateCache(String sessionId, String sessionToken, Map<String, Object> sessionMap) {
+		cache.set(getKey(sessionId, "MapCache"), sessionMap);
+		cache.set(getKey(sessionId, "TokenCache"), sessionToken);
+	}
+
+	private Map<String, Object> getOrCreateSessionMap(final PlayWebContext context, String sessionId) {
 		String sessionToken = getSessionToken(context, sessionId);
-		//get the claims, and if it fails, generate the session map
+		// get the claims, and if it fails, generate the session map
 		Map<String, Object> sessionMap;
 		try {
-			if(useCache && sessionToken.contentEquals(cache.get(getKey(sessionId, "TokenCache")))) {
-				sessionMap = (Map<String, Object>) cache.getOrElse(getKey(sessionId, "MapCache"), () -> {
-					return jwtAuthenticator.validateTokenAndGetClaims(sessionToken);
-				});
-			}
-			else {
+			if (useCache)
+				sessionMap = getSessionMapWithCache(sessionId, sessionToken);
+			else
 				sessionMap = jwtAuthenticator.validateTokenAndGetClaims(sessionToken);
-			}
-		}
-		catch(TechnicalException|NullPointerException e) {
+		} catch (TechnicalException | NullPointerException e) {
 			sessionMap = new HashMap<String, Object>();
-			//Ensures the map will be correctly built into a profile during the 'validate' call wrapped by validateTokenAndGetClaims()
+			// Ensures the map will be correctly built into a profile during the
+			// 'validate' call wrapped by validateTokenAndGetClaims()
 			sessionMap.put(JwtClaims.SUBJECT, sessionId);
 		}
 		return sessionMap;
+	}
+
+	private Map<String, Object> getSessionMapWithCache(String sessionId, String sessionToken)
+			throws TechnicalException, NullPointerException {
+		String cachedToken = cache.get(getKey(sessionId, "TokenCache"));
+		// check to see if the cache is up to date with the current sessionToken
+		if (sessionToken.contentEquals(cachedToken)) {
+			// If the cache is up to date, try to use it, if the cached map is
+			// missing, decrypt the token.
+			return (Map<String, Object>) cache.getOrElse(getKey(sessionId, "MapCache"), () -> {
+				return jwtAuthenticator.validateTokenAndGetClaims(sessionToken);
+			});
+		} else {
+			return jwtAuthenticator.validateTokenAndGetClaims(sessionToken);
+		}
 	}
 
 	@Override
@@ -116,30 +141,33 @@ public class PlayCookieStore implements PlaySessionStore {
 		String sessionId = getOrCreateSessionId(context);
 		return getOrCreateSessionMap(context, sessionId).get(getKey(sessionId, key));
 	}
-	
+
 	@Override
 	public void set(final PlayWebContext context, final String key, final Object value) {
 		String sessionId = getOrCreateSessionId(context);
 		Map<String, Object> sessionMap = getOrCreateSessionMap(context, sessionId);
-		if(key.contentEquals(Pac4jConstants.USER_PROFILES)) {
-			if (value instanceof LinkedHashMap<?,?>) {
-				@SuppressWarnings("unchecked")
-				LinkedHashMap<String, CommonProfile> profiles = (LinkedHashMap<String, CommonProfile>)value;
-				profiles.forEach((name, profile) ->{
-					profile.clearSensitiveData();
-				});
-				sessionMap.put(getKey(sessionId,key), profiles);
-			}
-			else {
-				CommonProfile profile = ((CommonProfile)value);
-				profile.clearSensitiveData();
-				sessionMap.put(getKey(sessionId,key), profile);
-			}
-		}
-		else {
-			sessionMap.put(getKey(sessionId,key), value);
+		if (key.contentEquals(Pac4jConstants.USER_PROFILES)) {
+			Object clearedProfiles = clearUserProfiles(value);
+			sessionMap.put(getKey(sessionId, key), clearedProfiles);
+		} else {
+			sessionMap.put(getKey(sessionId, key), value);
 		}
 		setSessionToken(context, sessionId, sessionMap);
+	}
+
+	private Object clearUserProfiles(Object value) {
+		if (value instanceof LinkedHashMap<?, ?>) {
+			@SuppressWarnings("unchecked")
+			LinkedHashMap<String, CommonProfile> profiles = (LinkedHashMap<String, CommonProfile>) value;
+			profiles.forEach((name, profile) -> {
+				profile.clearSensitiveData();
+			});
+			return profiles;
+		} else {
+			CommonProfile profile = ((CommonProfile) value);
+			profile.clearSensitiveData();
+			return profile;
+		}
 	}
 
 	public String getPrefix() {
@@ -158,22 +186,6 @@ public class PlayCookieStore implements PlaySessionStore {
 		this.timeout = timeout;
 	}
 
-	public static SecretSignatureConfiguration getSecretSignatureConfig() {
-		return secretSignatureConfig;
-	}
-
-	public static void setSecretSignatureConfig(SecretSignatureConfiguration secretSignatureConfig) {
-		PlayCookieStore.secretSignatureConfig = secretSignatureConfig;
-	}
-
-	public static SecretEncryptionConfiguration getSecretEncryptConfig() {
-		return secretEncryptConfig;
-	}
-
-	public static void setSecretEncryptConfig(SecretEncryptionConfiguration secretEncryptConfig) {
-		PlayCookieStore.secretEncryptConfig = secretEncryptConfig;
-	}
-
 	public JwtAuthenticator getJwtAuthenticator() {
 		return jwtAuthenticator;
 	}
@@ -190,12 +202,12 @@ public class PlayCookieStore implements PlaySessionStore {
 		this.jwtGenerator = jwtGenerator;
 	}
 
-	public static boolean isUseCache() {
+	public boolean isUseCache() {
 		return useCache;
 	}
 
-	public static void setUseCache(boolean useCache) {
-		PlayCookieStore.useCache = useCache;
+	public void setUseCache(boolean useCache) {
+		this.useCache = useCache;
 	}
 
 }

--- a/src/main/java/org/pac4j/play/store/PlayCookieStore.java
+++ b/src/main/java/org/pac4j/play/store/PlayCookieStore.java
@@ -13,10 +13,12 @@ import org.slf4j.LoggerFactory;
 import org.pac4j.jwt.credentials.authenticator.JwtAuthenticator;
 import org.pac4j.jwt.profile.JwtGenerator;
 import org.pac4j.jwt.JwtClaims;
-import org.pac4j.jwt.config.encryption.SecretEncryptionConfiguration;
+import org.pac4j.jwt.config.encryption.EncryptionConfiguration;
 import com.google.inject.Inject;
 
 import play.mvc.Http;
+
+import static org.pac4j.core.util.CommonHelper.assertNotNull;
 
 /**
  * The Cookie storage uses an encrypted JWT inside the Play Session cookie for
@@ -29,67 +31,44 @@ public class PlayCookieStore implements PlaySessionStore {
 
 	private static final Logger logger = LoggerFactory.getLogger(PlayCookieStore.class);
 
-	private final static String SEPARATOR = "$";
-
-	// prefix for the cache
-	private String prefix = "";
-
-	// 1 hour = 3600 seconds
-	private int timeout = 3600;
-
 	private JwtAuthenticator jwtAuthenticator;
 	private JwtGenerator<CommonProfile> jwtGenerator;
+	private final String tokenName = "pac4j";
 
 	@Inject
-	public PlayCookieStore(final SecretEncryptionConfiguration secretEncryptConfig) {
-		super();
+	public PlayCookieStore(final EncryptionConfiguration encryptConfig) {
+		assertNotNull("encryptConfig", encryptConfig);
 		this.jwtAuthenticator = new JwtAuthenticator();
-		this.jwtAuthenticator.addEncryptionConfiguration(secretEncryptConfig);
+		this.jwtAuthenticator.addEncryptionConfiguration(encryptConfig);
 		this.jwtGenerator = new JwtGenerator<CommonProfile>();
-		this.jwtGenerator.setEncryptionConfiguration(secretEncryptConfig);
-	}
-
-	String getKey(final String sessionId, final String key) {
-		return prefix + SEPARATOR + sessionId + SEPARATOR + key;
+		this.jwtGenerator.setEncryptionConfiguration(encryptConfig);
 	}
 
 	@Override
 	public String getOrCreateSessionId(final PlayWebContext context) {
-		final Http.Session session = context.getJavaSession();
-		// get current sessionId
-		String sessionId = session.get(Pac4jConstants.SESSION_ID);
-		logger.trace("retrieved sessionId: {}", sessionId);
-		// if null, generate a new one
-		if (sessionId == null) {
-			// generate id for session
-			sessionId = java.util.UUID.randomUUID().toString();
-			logger.debug("generated sessionId: {}", sessionId);
-			// and save it to session
-			session.put(Pac4jConstants.SESSION_ID, sessionId);
-		}
-		return sessionId;
+		return tokenName;
 	}
 
-	private String getSessionToken(final PlayWebContext context, String sessionId) {
+	private String getSessionToken(final PlayWebContext context) {
 		final Http.Session session = context.getJavaSession();
 		// get current sessionToken using sessionId
-		String sessionToken = session.get(sessionId);
+		String sessionToken = session.get(tokenName);
 		logger.trace("retrieved sessionToken: {}", sessionToken);
 		return sessionToken;
 	}
 
-	private void setSessionToken(final PlayWebContext context, String sessionId, Map<String, Object> sessionMap) {
+	private void setSessionToken(final PlayWebContext context, Map<String, Object> sessionMap) {
 		final Http.Session session = context.getJavaSession();
 		// save the session as a JWT, replacing the previous instance if
 		// necessary.
-		if (session.containsKey(sessionId))
-			session.remove(sessionId);
+		if (session.containsKey(tokenName))
+			session.remove(tokenName);
 		final String sessionToken = jwtGenerator.generate(sessionMap);
-		session.put(sessionId, sessionToken);
+		session.put(tokenName, sessionToken);
 	}
 
-	private Map<String, Object> getOrCreateSessionMap(final PlayWebContext context, String sessionId) {
-		String sessionToken = getSessionToken(context, sessionId);
+	private Map<String, Object> getOrCreateSessionMap(final PlayWebContext context) {
+		String sessionToken = getSessionToken(context);
 		// get the claims, and if it fails, generate the session map
 		Map<String, Object> sessionMap;
 		try {
@@ -98,28 +77,26 @@ public class PlayCookieStore implements PlaySessionStore {
 			sessionMap = new HashMap<String, Object>();
 			// Ensures the map will be correctly built into a profile during the
 			// 'validate' call wrapped by validateTokenAndGetClaims()
-			sessionMap.put(JwtClaims.SUBJECT, sessionId);
+			sessionMap.put(JwtClaims.SUBJECT, tokenName);
 		}
 		return sessionMap;
 	}
 
 	@Override
 	public Object get(final PlayWebContext context, final String key) {
-		String sessionId = getOrCreateSessionId(context);
-		return getOrCreateSessionMap(context, sessionId).get(getKey(sessionId, key));
+		return getOrCreateSessionMap(context).get(key);
 	}
 
 	@Override
 	public void set(final PlayWebContext context, final String key, final Object value) {
-		String sessionId = getOrCreateSessionId(context);
-		Map<String, Object> sessionMap = getOrCreateSessionMap(context, sessionId);
+		Map<String, Object> sessionMap = getOrCreateSessionMap(context);
 		if (key.contentEquals(Pac4jConstants.USER_PROFILES)) {
 			Object clearedProfiles = clearUserProfiles(value);
-			sessionMap.put(getKey(sessionId, key), clearedProfiles);
+			sessionMap.put(key, clearedProfiles);
 		} else {
-			sessionMap.put(getKey(sessionId, key), value);
+			sessionMap.put(key, value);
 		}
-		setSessionToken(context, sessionId, sessionMap);
+		setSessionToken(context, sessionMap);
 	}
 
 	private Object clearUserProfiles(Object value) {
@@ -135,22 +112,6 @@ public class PlayCookieStore implements PlaySessionStore {
 			profile.clearSensitiveData();
 			return profile;
 		}
-	}
-
-	public String getPrefix() {
-		return prefix;
-	}
-
-	public void setPrefix(String prefix) {
-		this.prefix = prefix;
-	}
-
-	public int getTimeout() {
-		return timeout;
-	}
-
-	public void setTimeout(int timeout) {
-		this.timeout = timeout;
 	}
 
 	public JwtAuthenticator getJwtAuthenticator() {

--- a/src/main/java/org/pac4j/play/store/PlayCookieStore.java
+++ b/src/main/java/org/pac4j/play/store/PlayCookieStore.java
@@ -1,0 +1,201 @@
+package org.pac4j.play.store;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.pac4j.core.context.Pac4jConstants;
+import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.play.PlayWebContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.pac4j.jwt.credentials.authenticator.JwtAuthenticator;
+import org.pac4j.jwt.profile.JwtGenerator;
+import org.pac4j.jwt.JwtClaims;
+import org.pac4j.jwt.config.encryption.SecretEncryptionConfiguration;
+import org.pac4j.jwt.config.signature.SecretSignatureConfiguration;
+import com.google.inject.Inject;
+
+import play.cache.CacheApi;
+import play.mvc.Http;
+
+public class PlayCookieStore implements PlaySessionStore {
+	
+	private static final Logger logger = LoggerFactory.getLogger(PlayCookieStore.class);
+
+    private final static String SEPARATOR = "$";
+
+    // prefix for the cache
+    private String prefix = "";
+
+    // 1 hour = 3600 seconds
+    private int timeout = 3600;
+    
+    private static boolean useCache = false;
+    private static SecretSignatureConfiguration secretSignatureConfig;
+    private static SecretEncryptionConfiguration secretEncryptConfig;
+    private JwtAuthenticator jwtAuthenticator;
+    private JwtGenerator<CommonProfile> jwtGenerator;
+    private final CacheApi cache;
+    
+	@Inject
+	public PlayCookieStore(final CacheApi cache) {
+		super();
+		this.jwtAuthenticator = new JwtAuthenticator(secretSignatureConfig, secretEncryptConfig);
+		this.jwtGenerator = new JwtGenerator<CommonProfile>(secretSignatureConfig, secretEncryptConfig);
+		this.cache = cache;
+	}
+
+	String getKey(final String sessionId, final String key) {
+        return prefix + SEPARATOR + sessionId + SEPARATOR + key;
+    }
+
+    @Override
+    public String getOrCreateSessionId(final PlayWebContext context) {
+        final Http.Session session = context.getJavaSession();
+        // get current sessionId
+        String sessionId = session.get(Pac4jConstants.SESSION_ID);
+        logger.trace("retrieved sessionId: {}", sessionId);
+        // if null, generate a new one
+        if (sessionId == null) {
+            // generate id for session
+            sessionId = java.util.UUID.randomUUID().toString();
+            logger.debug("generated sessionId: {}", sessionId);
+            // and save it to session
+            session.put(Pac4jConstants.SESSION_ID, sessionId);
+        }
+        return sessionId;
+    }
+	
+	private String getSessionToken(final PlayWebContext context, String sessionId) {
+		final Http.Session session = context.getJavaSession();
+        // get current sessionToken using sessionId
+        String sessionToken = session.get(sessionId);
+        logger.trace("retrieved sessionToken: {}", sessionToken);
+        return sessionToken;
+	}
+	
+	private void setSessionToken(final PlayWebContext context, String sessionId, Map<String, Object> sessionMap) {
+		final Http.Session session = context.getJavaSession();
+		//save the session as a JWT, replacing the previous instance if necessary.
+		if(session.containsKey(sessionId))
+			session.remove(sessionId);
+		final String sessionToken = jwtGenerator.generate(sessionMap);
+		session.put(sessionId, sessionToken);
+		if(useCache) {
+			cache.set(getKey(sessionId, "MapCache"), sessionMap);
+			cache.set(getKey(sessionId, "TokenCache"), sessionToken);
+		}
+	}
+	
+	private Map<String, Object> getOrCreateSessionMap(final PlayWebContext context, String sessionId){
+		String sessionToken = getSessionToken(context, sessionId);
+		//get the claims, and if it fails, generate the session map
+		Map<String, Object> sessionMap;
+		try {
+			if(useCache && sessionToken.contentEquals(cache.get(getKey(sessionId, "TokenCache")))) {
+				sessionMap = (Map<String, Object>) cache.getOrElse(getKey(sessionId, "MapCache"), () -> {
+					return jwtAuthenticator.validateTokenAndGetClaims(sessionToken);
+				});
+			}
+			else {
+				sessionMap = jwtAuthenticator.validateTokenAndGetClaims(sessionToken);
+			}
+		}
+		catch(TechnicalException|NullPointerException e) {
+			sessionMap = new HashMap<String, Object>();
+			//Ensures the map will be correctly built into a profile during the 'validate' call wrapped by validateTokenAndGetClaims()
+			sessionMap.put(JwtClaims.SUBJECT, sessionId);
+		}
+		return sessionMap;
+	}
+
+	@Override
+	public Object get(final PlayWebContext context, final String key) {
+		String sessionId = getOrCreateSessionId(context);
+		return getOrCreateSessionMap(context, sessionId).get(getKey(sessionId, key));
+	}
+	
+	@Override
+	public void set(final PlayWebContext context, final String key, final Object value) {
+		String sessionId = getOrCreateSessionId(context);
+		Map<String, Object> sessionMap = getOrCreateSessionMap(context, sessionId);
+		if(key.contentEquals(Pac4jConstants.USER_PROFILES)) {
+			if (value instanceof LinkedHashMap<?,?>) {
+				@SuppressWarnings("unchecked")
+				LinkedHashMap<String, CommonProfile> profiles = (LinkedHashMap<String, CommonProfile>)value;
+				profiles.forEach((name, profile) ->{
+					profile.clearSensitiveData();
+				});
+				sessionMap.put(getKey(sessionId,key), profiles);
+			}
+			else {
+				CommonProfile profile = ((CommonProfile)value);
+				profile.clearSensitiveData();
+				sessionMap.put(getKey(sessionId,key), profile);
+			}
+		}
+		else {
+			sessionMap.put(getKey(sessionId,key), value);
+		}
+		setSessionToken(context, sessionId, sessionMap);
+	}
+
+	public String getPrefix() {
+		return prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public int getTimeout() {
+		return timeout;
+	}
+
+	public void setTimeout(int timeout) {
+		this.timeout = timeout;
+	}
+
+	public static SecretSignatureConfiguration getSecretSignatureConfig() {
+		return secretSignatureConfig;
+	}
+
+	public static void setSecretSignatureConfig(SecretSignatureConfiguration secretSignatureConfig) {
+		PlayCookieStore.secretSignatureConfig = secretSignatureConfig;
+	}
+
+	public static SecretEncryptionConfiguration getSecretEncryptConfig() {
+		return secretEncryptConfig;
+	}
+
+	public static void setSecretEncryptConfig(SecretEncryptionConfiguration secretEncryptConfig) {
+		PlayCookieStore.secretEncryptConfig = secretEncryptConfig;
+	}
+
+	public JwtAuthenticator getJwtAuthenticator() {
+		return jwtAuthenticator;
+	}
+
+	public void setJwtAuthenticator(JwtAuthenticator jwtAuthenticator) {
+		this.jwtAuthenticator = jwtAuthenticator;
+	}
+
+	public JwtGenerator<CommonProfile> getJwtGenerator() {
+		return jwtGenerator;
+	}
+
+	public void setJwtGenerator(JwtGenerator<CommonProfile> jwtGenerator) {
+		this.jwtGenerator = jwtGenerator;
+	}
+
+	public static boolean isUseCache() {
+		return useCache;
+	}
+
+	public static void setUseCache(boolean useCache) {
+		PlayCookieStore.useCache = useCache;
+	}
+
+}


### PR DESCRIPTION
Here's my initial attempt at creating a PlayCookieStore, based on our discussion in #146 
I'm not quite sure what else is needed. I haven't thoroughly tested this yet, and would appreciate some help in doing so. I added an option to use Play's CacheApi in the case of the token not having changed since its previous access, which should improve efficiency in the cases where several operations are done in a single request so that the token doesn't have to be converted quite as often.

I suspect that some additional logout logic is needed to handle this.

Finally, in order to use this, the user should add 
    `bind(PlaySessionStore.class).to(PlayCookieStore.class);
    PlayCookieStore.setSecretEncryptConfig(new SecretEncryptionConfiguration("mysecret"));
    PlayCookieStore.setSecretSignatureConfig(new SecretSignatureconfiguration("MyOtherSecret"));`
to their SecurityModule

Please let me know if there are any further changes that you'd like.