### PR TITLE
Replace deprecated methods

### DIFF
--- a/shared/src/main/java/org/pac4j/play/PlayWebContext.java
+++ b/shared/src/main/java/org/pac4j/play/PlayWebContext.java
@@ -127,7 +127,7 @@ public class PlayWebContext implements WebContext {
 
     @Override
     public String getRequestHeader(final String name) {
-        return request.getHeader(name);
+        return request.header(name).orElse(null);
     }
 
     @Override
@@ -233,7 +233,7 @@ public class PlayWebContext implements WebContext {
         httpCookies.forEach(httpCookie -> {
             final Cookie cookie = new Cookie(httpCookie.name(), httpCookie.value());
             if(httpCookie.domain() != null) {
-            	cookie.setDomain(httpCookie.domain());
+                cookie.setDomain(httpCookie.domain());
             }
             cookie.setHttpOnly(httpCookie.httpOnly());
             if(httpCookie.maxAge() != null) {

--- a/shared/src/main/java/org/pac4j/play/store/PlayCookieSessionStore.java
+++ b/shared/src/main/java/org/pac4j/play/store/PlayCookieSessionStore.java
@@ -118,7 +118,7 @@ public class PlayCookieSessionStore implements PlaySessionStore {
 
     // based on http://lifelongprogrammer.blogspot.com/2013/11/java-use-zip-stream-and-base64-to-compress-big-string.html
     public static byte[] uncompressBytes(byte [] zippedBytes) {
-        try (final GZIPInputStream zipInputStream = new GZIPInputStream(new ByteArrayInputStream(zippedBytes))) {
+        try (GZIPInputStream zipInputStream = new GZIPInputStream(new ByteArrayInputStream(zippedBytes))) {
             return IOUtils.toByteArray(zipInputStream);
         } catch (IOException e) {
             logger.error("Unable to uncompress session cookie", e);
@@ -128,7 +128,7 @@ public class PlayCookieSessionStore implements PlaySessionStore {
 
     public static byte[] compressBytes(byte[] srcBytes) {
         final ByteArrayOutputStream resultBao = new ByteArrayOutputStream();
-        try (final GZIPOutputStream zipOutputStream = new GZIPOutputStream(resultBao)) {
+        try (GZIPOutputStream zipOutputStream = new GZIPOutputStream(resultBao)) {
             zipOutputStream.write(srcBytes);
         } catch (IOException e) {
             logger.error("Unable to compress session cookie", e);

--- a/shared/src/main/java/org/pac4j/play/store/PlayCookieSessionStore.java
+++ b/shared/src/main/java/org/pac4j/play/store/PlayCookieSessionStore.java
@@ -118,29 +118,22 @@ public class PlayCookieSessionStore implements PlaySessionStore {
 
     // based on http://lifelongprogrammer.blogspot.com/2013/11/java-use-zip-stream-and-base64-to-compress-big-string.html
     public static byte[] uncompressBytes(byte [] zippedBytes) {
-        GZIPInputStream zipInputStream = null;
-        try {
-            zipInputStream = new GZIPInputStream(new ByteArrayInputStream(zippedBytes));
+        try (final GZIPInputStream zipInputStream = new GZIPInputStream(new ByteArrayInputStream(zippedBytes))) {
             return IOUtils.toByteArray(zipInputStream);
         } catch (IOException e) {
             logger.error("Unable to uncompress session cookie", e);
             return null;
-        } finally {
-            IOUtils.closeQuietly(zipInputStream);
         }
     }
 
     public static byte[] compressBytes(byte[] srcBytes) {
-        ByteArrayOutputStream resultBao = new ByteArrayOutputStream();
-        GZIPOutputStream zipOutputStream = null;
-        try {
-            zipOutputStream = new GZIPOutputStream(resultBao);
+        final ByteArrayOutputStream resultBao = new ByteArrayOutputStream();
+        try (final GZIPOutputStream zipOutputStream = new GZIPOutputStream(resultBao)) {
             zipOutputStream.write(srcBytes);
         } catch (IOException e) {
             logger.error("Unable to compress session cookie", e);
             return null;
         }
-        IOUtils.closeQuietly(zipOutputStream);
 
         return resultBao.toByteArray();
     }


### PR DESCRIPTION
Replaced the `getHeader` method with the recommended `header` method, which returns an optional (this is somewhat related to #239, since this deprecated method will be removed in the next Play version).
Replaced the `IOUtils.closeQuietly` method with a `try-with-resources` structure.
As an added bonus, the `compressBytes` method now also closes its `OutputStream` when an exception occurs.