### PR TITLE
Increase security in ShiroAesDataEncrypter

### DIFF
--- a/shared/src/main/java/org/pac4j/play/store/ShiroAesDataEncrypter.java
+++ b/shared/src/main/java/org/pac4j/play/store/ShiroAesDataEncrypter.java
@@ -6,7 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
-import java.util.UUID;
+import java.security.SecureRandom;
 
 /**
  * A DataEncrypter based on the Shiro library and AES encryption.
@@ -22,12 +22,22 @@ public class ShiroAesDataEncrypter implements DataEncrypter {
 
     private byte[] key;
 
-    public ShiroAesDataEncrypter() {
-        final String sKey = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
-        logger.info("Generated key: {}", sKey);
-        this.key = sKey.getBytes(StandardCharsets.UTF_8);
+    public ShiroAesDataEncrypter(final byte[] key) {
+        CommonHelper.assertNotNull("key", key);
+        this.key = key.clone();
     }
 
+    public ShiroAesDataEncrypter() {
+        SecureRandom random = new SecureRandom();
+        byte bytes[] = new byte[16];
+        random.nextBytes(bytes);
+        this.key = bytes;
+    }
+
+    // This method cannot generate a key whose first byte is in range 128-191
+    // (both inclusive), since byte sequence starting with 10xxxxxx are not
+    // valid UTF8-encodings of any string.
+    @Deprecated
     public ShiroAesDataEncrypter(final String key) {
         CommonHelper.assertNotNull("key", key);
         logger.info("Using key: {}", key);

--- a/shared/src/test/java/org/pac4j/play/store/ShiroAesDataEncrypterTests.java
+++ b/shared/src/test/java/org/pac4j/play/store/ShiroAesDataEncrypterTests.java
@@ -3,6 +3,7 @@ package org.pac4j.play.store;
 import org.junit.Test;
 import org.pac4j.core.util.TestsConstants;
 
+import java.util.Arrays;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.*;
@@ -15,7 +16,26 @@ import static org.junit.Assert.*;
  */
 public class ShiroAesDataEncrypterTests implements TestsConstants {
 
-    private final ShiroAesDataEncrypter encrypter =  new ShiroAesDataEncrypter();
+    private final ShiroAesDataEncrypter encrypter = new ShiroAesDataEncrypter();
+
+    @Test
+    public void testCanUseKey0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA() {
+        final byte[] key = new byte[16];
+        Arrays.fill(key, (byte) 0xAA);
+
+        final ShiroAesDataEncrypter cryptoEngine = new ShiroAesDataEncrypter(key);
+
+        final byte[] plaintext = new byte[256];
+        for (int i = 0; i < plaintext.length; ++i) {
+            plaintext[i] = (byte) i;
+        }
+
+        final byte[] ciphertext = cryptoEngine.encrypt(plaintext);
+        ++key[0];
+        final byte[] roundTripPlaintext = cryptoEngine.decrypt(ciphertext);
+
+        assertArrayEquals(plaintext, roundTripPlaintext);
+    }
 
     @Test
     public void testOK() {


### PR DESCRIPTION
Deprecate the constructor which takes the AES key as a String.  The
mapping from String values into the AES key space was not surjective.

Generate more secure random keys in the default constructor: sample
from the entire key space, and use a SecureRandom to do it.

Add a constructor which takes the AES key as a byte array, enabling
the user to supply their own key.