### PR TITLE
Always return true when destroying session.

### DIFF
--- a/shared/src/main/java/org/pac4j/play/store/PlayCacheSessionStore.java
+++ b/shared/src/main/java/org/pac4j/play/store/PlayCacheSessionStore.java
@@ -143,9 +143,8 @@ public class PlayCacheSessionStore implements SessionStore {
             context.setRequestAttribute(Pac4jConstants.SESSION_ID, null);
             final String prefixedSessionKey = getPrefixedSessionKey(sessionId);
             store.remove(prefixedSessionKey);
-            return true;
         }
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
The default logic in Pac4j breaks when a session store does not return true when destroying a session.

This is the case of org.pac4j.core.context.session.JEESessionStore#destroySession().

The logic that breaks is here https://github.com/pac4j/pac4j/blob/72037309c19280808a01975069b0b1f43eefd481/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultLogoutLogic.java#L93