### PR TITLE
all: Play 2.9.0 / add Scala 3 / drop Scala 2.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ perfStats.log
 .pmd
 .pmdruleset.xml
 .DS_Store
+.bloop
+.vscode
+.metals

--- a/play-pac4j_2.13/pom.xml
+++ b/play-pac4j_2.13/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>play-pac4j-parent</artifactId>
-        <version>12.0.0-PLAY2.8-RC2-SNAPSHOT</version>
+        <version>12.0.0-PLAY2.9</version>
     </parent>
 
     <artifactId>play-pac4j_2.13</artifactId>

--- a/play-pac4j_2.13/src/main/scala/org/pac4j/play/scala/ScalaCompat.scala
+++ b/play-pac4j_2.13/src/main/scala/org/pac4j/play/scala/ScalaCompat.scala
@@ -1,0 +1,10 @@
+package org.pac4j.play.scala
+
+/**
+ * @since 12.0.0
+ */
+object ScalaCompat {
+
+  val Converters = _root_.scala.jdk.CollectionConverters
+  
+}

--- a/play-pac4j_3/pom.xml
+++ b/play-pac4j_3/pom.xml
@@ -5,18 +5,13 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>play-pac4j-parent</artifactId>
-        <version>12.0.0-PLAY2.8-RC2-SNAPSHOT</version>
+        <version>12.0.0-PLAY2.9</version>
     </parent>
 
-    <artifactId>play-pac4j_2.12</artifactId>
+    <artifactId>play-pac4j_3</artifactId>
     <packaging>jar</packaging>
-    <name>pac4j implementation for Play framework (Scala 2.12)</name>
-    <description>Security library for Play framework based on pac4j using Scala 2.12</description>
-
-    <properties>
-        <scala.version>2.12</scala.version>
-        <scala.maven.version>2.12.11</scala.maven.version>
-    </properties>
+    <name>pac4j implementation for Play framework (Scala 3)</name>
+    <description>Security library for Play framework based on pac4j using Scala 3</description>
 
     <dependencies>
         <dependency>
@@ -30,6 +25,11 @@
             <artifactId>play-cache_${scala.version}</artifactId>
             <version>${play.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala3-library_3</artifactId>
+            <version>3.3.1</version>
         </dependency>
 
         <!-- tests -->

--- a/play-pac4j_3/spotbugs-exclude.xml
+++ b/play-pac4j_3/spotbugs-exclude.xml
@@ -6,9 +6,6 @@
         <Package name="org.pac4j.play.scala" />
     </Match>
     <Match>
-        <Package name="org.pac4j.play.scala.deadbolt2" />
-    </Match>
-    <Match>
         <Class name="~.*MockInMemoryAsyncCacheApi.*" />
     </Match>
 </FindBugsFilter>

--- a/play-pac4j_3/src/main/java/org/pac4j/play/ScalaCompatibility.java
+++ b/play-pac4j_3/src/main/java/org/pac4j/play/ScalaCompatibility.java
@@ -1,21 +1,22 @@
 package org.pac4j.play;
 
 import play.api.mvc.AnyContentAsFormUrlEncoded;
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
+import scala.collection.immutable.Seq;
+import scala.jdk.CollectionConverters;
 
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @author Karel Cemus
+ * @author Jerome LELEU
+ * @since 12.0.0
  */
 class ScalaCompatibility {
 
     static Map<String, String[]> parseBody(final AnyContentAsFormUrlEncoded body) {
         final Map<String, String[]> p = new HashMap<>();
         final scala.collection.immutable.Map<String, Seq<String>> scalaParameters = body.asFormUrlEncoded().get();
-        for (final String key : JavaConverters.setAsJavaSet(scalaParameters.keySet())) {
+        for (final String key : CollectionConverters.SetHasAsJava(scalaParameters.keySet()).asJava()) {
             final Seq<String> v = scalaParameters.get(key).get();
             final String[] values = new String[v.size()];
             v.copyToArray(values);

--- a/play-pac4j_3/src/main/scala/org/pac4j/play/scala/ScalaCompat.scala
+++ b/play-pac4j_3/src/main/scala/org/pac4j/play/scala/ScalaCompat.scala
@@ -1,0 +1,10 @@
+package org.pac4j.play.scala
+
+/**
+ * @since 12.0.0
+ */
+object ScalaCompat {
+
+  val Converters = _root_.scala.jdk.CollectionConverters
+  
+}

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>play-pac4j-parent</artifactId>
     <packaging>pom</packaging>
     <name>pac4j parent for Play</name>
-    <version>12.0.0-PLAY2.8-RC2-SNAPSHOT</version>
+    <version>12.0.0-PLAY2.9</version>
     <url>https://github.com/pac4j/play-pac4j</url>
 
     <licenses>
@@ -62,23 +62,24 @@
     </repositories>
 
     <properties>
-        <pac4j.version>6.0.0-RC9</pac4j.version>
-        <play.version>2.8.20</play.version>
+        <pac4j.version>6.0.0-RC8</pac4j.version>
+        <play.version>2.9.0</play.version>
         <java.version>17</java.version>
-        <guice.version>7.0.0</guice.version>
+        <guice.version>6.0.0</guice.version>
         <shiro.version>1.12.0</shiro.version>
         <ehcache.version>2.10.9.2</ehcache.version>
-        <scalatest.version>3.3.0-SNAP4</scalatest.version>
+        <scalatest.version>3.2.17</scalatest.version>
         <scala.version>2.13</scala.version>
-        <scala.maven.version>2.13.10</scala.maven.version>
+        <scala.maven.version>2.13.12</scala.maven.version>
         <junit.version>4.13.2</junit.version>
+        <selenium.version>4.12.1</selenium.version>
         <mockito.version>5.6.0</mockito.version>
         <pmdVersion>6.55.0</pmdVersion>
     </properties>
 
     <modules>
-        <module>play-pac4j_2.12</module>
         <module>play-pac4j_2.13</module>
+        <module>play-pac4j_3</module>
     </modules>
 
     <dependencies>
@@ -129,6 +130,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>${selenium.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/shared/src/main/java/org/pac4j/play/PlayWebContext.java
+++ b/shared/src/main/java/org/pac4j/play/PlayWebContext.java
@@ -109,7 +109,7 @@ public class PlayWebContext implements WebContext {
 
     protected Object getBody() {
         if (scalaRequest != null && scalaRequest.hasBody() && scalaRequest instanceof Request) {
-            return ((Request) scalaRequest).body();
+            return ((Request<?>) scalaRequest).body();
         } else if (javaRequest.hasBody() && javaRequest instanceof Http.Request) {
             return ((Http.Request) javaRequest).body();
         }
@@ -253,6 +253,11 @@ public class PlayWebContext implements WebContext {
     public Http.RequestHeader supplementRequest(final Http.RequestHeader request) {
         logger.trace("supplement request with: {} and session: {}", this.javaRequest.attrs(), session);
         return request.withAttrs(this.javaRequest.attrs()).addAttr(RequestAttrKey.Session().asJava(), new AssignedCell<>(session.asScala()));
+    }
+
+    public <A> Request<A> supplementRequest(Request<A> request) {
+        logger.trace("supplement request with: {} and session: {}", this.javaRequest.attrs(), session);
+        return request.withAttrs(this.javaRequest.attrs().asScala()).addAttr(RequestAttrKey.Session(), new AssignedCell<>(session.asScala()));
     }
 
     public Result supplementResponse(final Result result) {

--- a/shared/src/main/scala/org/pac4j/play/scala/Pac4jScalaTemplateHelper.scala
+++ b/shared/src/main/scala/org/pac4j/play/scala/Pac4jScalaTemplateHelper.scala
@@ -9,7 +9,7 @@ import org.pac4j.core.profile.{ProfileManager, UserProfile}
 import org.pac4j.play.context.PlayFrameworkParameters
 import play.api.mvc.RequestHeader
 
-import scala.collection.JavaConverters._
+import ScalaCompat.Converters._
 
 /**
   * This is a helper which can be used to access the current user profile from a twirl template.

--- a/shared/src/main/scala/org/pac4j/play/scala/Security.scala
+++ b/shared/src/main/scala/org/pac4j/play/scala/Security.scala
@@ -2,13 +2,13 @@ package org.pac4j.play.scala
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
-import scala.language.higherKinds
 import play.api.mvc._
 import org.pac4j.core.config.Config
 import org.pac4j.core.profile.UserProfile
-import org.pac4j.play.PlayWebContext
 import org.pac4j.play.context.PlayFrameworkParameters
 import org.pac4j.play.result.PlayWebContextResultHolder
+import play.api.http.FileMimeTypes
+import play.api.i18n.{Langs, MessagesApi}
 
 /**
  * <p>To protect a resource, the {@link #Secure} methods must be used.</p>
@@ -35,14 +35,15 @@ trait Security[P<:UserProfile] extends BaseController {
 }
 
 
-case class SecureAction[P<:UserProfile, ContentType, R[X]>:AuthenticatedRequest[P, X]<:Request[X]](clients: String, authorizers: String, matchers: String, parser: BodyParser[ContentType], config: Config)(implicit implicitExecutionContext: ExecutionContext) extends ActionBuilder[R, ContentType] {
-  import scala.collection.JavaConverters._
+case class SecureAction[P <: UserProfile, ContentType, R[X]>:AuthenticatedRequest[P, X]<:Request[X]](
+  clients: String, authorizers: String, matchers: String, parser: BodyParser[ContentType], config: Config
+)(implicit implicitExecutionContext: ExecutionContext) extends ActionBuilder[R, ContentType] {
+  import ScalaCompat.Converters._
   import scala.compat.java8.FutureConverters._
   import scala.concurrent.Future
-  import org.pac4j.core.profile.ProfileManager
   import org.pac4j.play.scala.SecureAction._
 
-  protected def executionContext = implicitExecutionContext
+  protected def executionContext: ExecutionContext = implicitExecutionContext
 
 
   /**
@@ -66,25 +67,24 @@ case class SecureAction[P<:UserProfile, ContentType, R[X]>:AuthenticatedRequest[
   def apply[A](action: Action[A]): Action[A] =
     copy[P,A,R](parser = action.parser).async(action.parser)(r => action.apply(r))
 
-  def invokeBlock[A](request: Request[A], block: R[A] => Future[Result]) = {
+  def invokeBlock[A](request: Request[A], block: R[A] => Future[Result]): Future[Result] = {
     val secureAction = new org.pac4j.play.java.SecureAction(config)
     val parameters = new PlayFrameworkParameters(request)
-    secureAction.call(parameters, clients, authorizers, matchers).toScala.flatMap[play.api.mvc.Result](r =>
-      if (r.isInstanceOf[PlayWebContextResultHolder]) {
-        val webContext = r.asInstanceOf[PlayWebContextResultHolder].getPlayWebContext
+    secureAction.call(parameters, clients, authorizers, matchers).toScala.flatMap[play.api.mvc.Result] {
+      case holder: PlayWebContextResultHolder =>
+        val webContext = holder.getPlayWebContext
         val sessionStore = config.getSessionStoreFactory.newSessionStore(parameters)
         val profileManager = config.getProfileManagerFactory.apply(webContext, sessionStore)
-        val profiles = profileManager.getProfiles()
+        val profiles = profileManager.getProfiles
         logger.debug("profiles: {}", profiles)
         val sProfiles = profiles.asScala.toList.asInstanceOf[List[P]]
-        val sRequest = webContext.supplementRequest(request.asJava).asScala.asInstanceOf[Request[A]]
+        val sRequest = webContext.supplementRequest(request)
         block(AuthenticatedRequest(sProfiles, sRequest))
-      } else {
+      case r =>
         Future successful {
           r.asScala
         }
-      }
-    )
+    }
   }
 }
 
@@ -100,12 +100,12 @@ trait SecurityComponents extends ControllerComponents {
   def config: Config
   def parser: BodyParsers.Default
 
-  @inline def actionBuilder = components.actionBuilder
-  @inline def parsers = components.parsers
-  @inline def messagesApi = components.messagesApi
-  @inline def langs = components.langs
-  @inline def fileMimeTypes = components.fileMimeTypes
-  @inline def executionContext = components.executionContext
+  @inline def actionBuilder: ActionBuilder[Request, AnyContent] = components.actionBuilder
+  @inline def parsers: PlayBodyParsers = components.parsers
+  @inline def messagesApi: MessagesApi = components.messagesApi
+  @inline def langs: Langs = components.langs
+  @inline def fileMimeTypes: FileMimeTypes = components.fileMimeTypes
+  @inline def executionContext: ExecutionContext = components.executionContext
 }
 
 @Singleton

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -28,6 +28,10 @@
         <Bug pattern="EI_EXPOSE_REP" />
     </Match>
     <Match>
+        <Class name="~.*MockInMemoryAsyncCacheApi.*" />
+        <Bug pattern="EI_EXPOSE_REP" />
+    </Match>    
+    <Match>
         <Class name="~.*PlayCacheStore"/>
         <Bug pattern="EI_EXPOSE_REP2" />
     </Match>


### PR DESCRIPTION
 - add support for Play 2.9.0
 - add support for Scala 3
 - drop support for Scala 2.12 as Play 2.9.0 does not support Scala 2.12
 - adjust web context and security wrt. changes in play 2.9.0
 - upgrade various dependencies
 - downgrade guice / scalatest as Play uses those.

 See: https://github.com/playframework/playframework/commit/b5ef04a6beb34c903984b3859da20a2df23a9f59