### PR TITLE
Scala versions supported by Play 2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ It's based on the **[pac4j security engine](https://github.com/pac4j/pac4j)**. I
 
 | JDK  | Play version | pac4j version | play-pac4j version | Modules (Java & Scala)                          | Usage of Lombok | Status           |
 |------|--------------|---------------|--------------------|-------------------------------------------------|-----------------|------------------|
-| 17   | 3.0          | 6.x           | 12.0.x-PLAY3.0     | play-pac4j_2.12 play-pac4j_2.13                 | Yes             | In development   |
-| 17   | 2.9          | 6.x           | 12.0.x-PLAY2.9     | play-pac4j_2.12 play-pac4j_2.13                 | Yes             | In development   |
+| 17   | 3.0          | 6.x           | 12.0.x-PLAY3.0     | play-pac4j_2.13 play-pac4j_3                    | Yes             | In development   |
+| 17   | 2.9          | 6.x           | 12.0.x-PLAY2.9     | play-pac4j_2.13 play-pac4j_3                    | Yes             | In development   |
 | 17   | 2.8          | 6.x           | 12.0.x-PLAY2.8     | play-pac4j_2.12 play-pac4j_2.13                 | Yes             | In development   |
 | 11   | 2.8          | 5.x           | 11.0.x-PLAY2.8     | play-pac4j_2.12 play-pac4j_2.13                 | No              | Production ready |
 | 11   | 2.8          | 4.x           | 10.x               | play-pac4j_2.12 play-pac4j_2.13                 | No              | Production ready |


### PR DESCRIPTION
Play 2.9 does not support Scala 2.12 anymore, but now supports Scala 3.