### PR TITLE
Guice 7.0.0 removes dependnecy to javax.inject, setting it to 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <pac4j.version>6.0.0-RC10-SNAPSHOT</pac4j.version>
         <play.version>2.9.0</play.version>
         <java.version>17</java.version>
-        <guice.version>7.0.0</guice.version>
+        <guice.version>6.0.0</guice.version>
         <shiro.version>1.12.0</shiro.version>
         <ehcache.version>2.10.9.2</ehcache.version>
         <scalatest.version>3.2.17</scalatest.version>
@@ -98,6 +98,7 @@
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <version>${guice.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.shiro</groupId>


### PR DESCRIPTION
I get the following exception: 
`Exception in thread "main" java.lang.NoSuchMethodError: 'com.google.inject.Provider com.google.inject.util.Providers.guicify(javax.inject.Provider)'
`

It's due to Guice which is transitioning from JEE to Jakarta, as explained at https://github.com/google/guice/wiki/Guice700#changes-since-guice-510
