### PR TITLE
dependencies: downgrade Guice to version that Play 2.9/3.0 uses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <pac4j.version>6.0.0</pac4j.version>
         <play.version>3.0.0</play.version>
         <java.version>17</java.version>
-        <guice.version>7.0.0</guice.version>
+        <guice.version>6.0.0</guice.version>
         <shiro.version>1.13.0</shiro.version>
         <ehcache.version>2.10.9.2</ehcache.version>
         <scalatest.version>3.2.17</scalatest.version>


### PR DESCRIPTION
@leleuj Is it possible to fixate renovate bot to be on Guice v6.0.0 - Play 2.9 / 3.0 use 6.0.0 and fail with version 7.