### PR TITLE
Compile Scala 3 version with Scala LTS (3.3.4)

### DIFF
--- a/play-pac4j_3/pom.xml
+++ b/play-pac4j_3/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <scala.major.version>3</scala.major.version>
-        <scala.version>3.6.1</scala.version>
+        <scala.version>3.3.4</scala.version>
         <scala.maven.version>3.3.3</scala.maven.version>
     </properties>
 


### PR DESCRIPTION
Compile Scala 3 version with Scala LTS (3.3.4). See issue https://github.com/pac4j/play-pac4j/issues/731