### PR TITLE
Fix session merge priority in supplementResponse

### DIFF
--- a/shared/src/main/java/org/pac4j/play/PlayWebContext.java
+++ b/shared/src/main/java/org/pac4j/play/PlayWebContext.java
@@ -312,8 +312,15 @@ public class PlayWebContext implements WebContext {
             if (session == null || resultSession == null) {
                 r = r.withSession(session != null ? session : resultSession);
             } else {
-                Map<String, String> merged = new HashMap<>(session.data());
-                resultSession.data().forEach(merged::putIfAbsent);
+                Map<String, String> merged = new HashMap<>(resultSession.data());
+                Map<String, String> initialData = initialSession != null ? initialSession.data() : Map.of();
+                // Only add/modify keys that pac4j added or modified, not ones that
+                // were already present in the initial session or are unchanged.
+                session.data().forEach((k, v) -> {
+                    if (!initialData.containsKey(k) || !Objects.equals(initialData.get(k), v)) {
+                        merged.putIfAbsent(k, v);
+                    }
+                });
                 r = r.withSession(new Http.Session(merged));
             }
         }


### PR DESCRIPTION
When a controller removes a session key using removeFromSession(), the key can reappear in the response. This occurs when both:

1. The controller modifies the Result's session (e.g. removes a key)
2. pac4j writes to its internal session during the request, triggering hasSessionChanged()

The current merge logic gives priority to PlayWebContext.session over the controller's Result.session. Instead, this change implements a 3-way merge that respects the controller's intent while preserving pac4j's actual changes. It checks if anything in the PlayWebContext.session is different than what is in PlayWebContext.initialSession. If there is a new value in session not in initialSession, or the value in session and initalSession for that key differs, it merges it into the controller's version of the session.

The previous logic is still fine for things like when pac4j adds a new key during auth or modifies an existing key. But now, if there's a conflict between internal state and the session attached to the result passed in, the result wins so that keys can be removed correctly.