### PR TITLE
fix(security): Upgrade pac4j to 6.3.3 for CVE-2026-29000

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     </repositories>
 
     <properties>
-        <pac4j.version>6.2.2</pac4j.version>
+        <pac4j.version>6.3.3</pac4j.version>
         <play.version>3.0.10</play.version>
         <java.version>17</java.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
## Summary
- Upgrades pac4j from 6.2.2 to 6.3.3 to fix CVE-2026-29000

## Security Issue
CVE-2026-29000 is a critical (CVSS 9.1) JWT authentication bypass in pac4j-jwt's `JwtAuthenticator.validate()`.

## Changes
- [x] Updated pac4j version in pom.xml
- [x] Verified no API changes needed (no `.validate()` calls found)

## Testing
- [x] Local build verified (dependency resolution successful)
- [ ] CI will verify full test suite

---
**Note:** This PR includes maintainer edit permissions enabled for your convenience.